### PR TITLE
deps: update dependency versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	],
+	"postStartCommand": "npm install && (gh extension install seachicken/gh-poi || true)",
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "terser-webpack-plugin": "^5.3.1",
         "tfx-cli": "^0.11.0",
         "ts-jest": "^26.5.6",
-        "ts-loader": "^9.2.8",
+        "ts-loader": "^9.2.9",
         "tslib": "^2.4.0",
         "typescript": "^4.6.3",
         "typescript-plugin-css-modules": "^3.4.0",
@@ -15542,9 +15542,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
-      "integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.9.tgz",
+      "integrity": "sha512-b0+vUY2/enb0qYtDQuNlDnJ9900NTiPiJcDJ6sY7ax1CCCwXfYIqPOMm/BwW7jsF1km+Oz8W9s31HLuD+FLIMg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -28639,9 +28639,9 @@
       }
     },
     "ts-loader": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
-      "integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.9.tgz",
+      "integrity": "sha512-b0+vUY2/enb0qYtDQuNlDnJ9900NTiPiJcDJ6sY7ax1CCCwXfYIqPOMm/BwW7jsF1km+Oz8W9s31HLuD+FLIMg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.29.4",
-        "eslint-plugin-react-hooks": "^4.4.0",
+        "eslint-plugin-react-hooks": "^4.5.0",
         "eslint-webpack-plugin": "^3.1.1",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^26.1.0",
@@ -6533,9 +6533,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -21878,9 +21878,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
-      "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+      "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "prettier": "^2.6.2",
         "process": "^0.11.10",
         "rimraf": "^3.0.2",
-        "sass": "^1.50.1",
+        "sass": "^1.51.0",
         "sass-loader": "^12.6.0",
         "style-loader": "^3.3.1",
         "terser-webpack-plugin": "^5.3.1",
@@ -13705,9 +13705,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
-      "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -27186,9 +27186,9 @@
       }
     },
     "sass": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
-      "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+      "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",
-    "eslint-plugin-react-hooks": "^4.4.0",
+    "eslint-plugin-react-hooks": "^4.5.0",
     "eslint-webpack-plugin": "^3.1.1",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "terser-webpack-plugin": "^5.3.1",
     "tfx-cli": "^0.11.0",
     "ts-jest": "^26.5.6",
-    "ts-loader": "^9.2.8",
+    "ts-loader": "^9.2.9",
     "tslib": "^2.4.0",
     "typescript": "^4.6.3",
     "typescript-plugin-css-modules": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prettier": "^2.6.2",
     "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "sass": "^1.50.1",
+    "sass": "^1.51.0",
     "sass-loader": "^12.6.0",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.1",


### PR DESCRIPTION
- build(deps-dev): bump sass from 1.50.1 to 1.51.0
- build(deps-dev): bump ts-loader from 9.2.8 to 9.2.9
- build(deps-dev): bump eslint-plugin-react-hooks from 4.4.0 to 4.5.0
- run npm install and gh extension on start
