### PR TITLE
deps: update to latest dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "azure-devops-ui": "^2.167.31",
         "preact": "^10.7.1",
         "react-fast-compare": "^3.2.0",
-        "usehooks-ts": "^2.5.1",
+        "usehooks-ts": "^2.5.2",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -15889,9 +15889,9 @@
       }
     },
     "node_modules/usehooks-ts": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.5.1.tgz",
-      "integrity": "sha512-vGIl/r7SMey3Uwe/YykLTJ5AmrlBe02MwQxsUBxNWDmfegEdHXXQaJ2VoOEayKW85Zwr+NyIhfVG+xrQYjtXVg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.5.2.tgz",
+      "integrity": "sha512-keONG+M5aax8eN9kEZeayNBgK+7MSLVGCuP18pSdce5D5iLiImCxqkm04GWYSkA7Xpo0GWnPOK3cXAOY/K+T1g==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -28919,9 +28919,9 @@
       "dev": true
     },
     "usehooks-ts": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.5.1.tgz",
-      "integrity": "sha512-vGIl/r7SMey3Uwe/YykLTJ5AmrlBe02MwQxsUBxNWDmfegEdHXXQaJ2VoOEayKW85Zwr+NyIhfVG+xrQYjtXVg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.5.2.tgz",
+      "integrity": "sha512-keONG+M5aax8eN9kEZeayNBgK+7MSLVGCuP18pSdce5D5iLiImCxqkm04GWYSkA7Xpo0GWnPOK3cXAOY/K+T1g==",
       "requires": {}
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "azure-devops-ui": "^2.167.31",
     "preact": "^10.7.1",
     "react-fast-compare": "^3.2.0",
-    "usehooks-ts": "^2.5.1",
+    "usehooks-ts": "^2.5.2",
     "uuid": "^8.3.2"
   },
   "override": {


### PR DESCRIPTION
- build(deps-dev): bump ts-loader from 9.2.9 to 9.3.0
- build(deps): bump @microsoft/applicationinsights-web from 2.8.1 to 2.8.2
- build(deps-dev): bump @typescript-eslint/parser from 5.21.0 to 5.22.0
- build(deps-dev): bump @typescript-eslint/eslint-plugin
- build(deps): bump usehooks-ts from 2.5.1 to 2.5.2
